### PR TITLE
 Get GenomicsDB-Python to build for Python version 3.7/3.8/3.9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@ Experimental Python Bindings using cython to the native [GenomicsDB](https://git
 
 To build:
 ```
-git clone https://github.com/nalinigans/GenomicsDB-Python.git
+git clone https://github.com/GenomicsDB/GenomicsDB-Python.git
 cd GenomicsDB-Python
 virtualenv -p python3 env
 source env/bin/activate > /dev/null

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ pip install genomicsdb
 ```
 
 ## Development
-See [instructions](https://github.com/nalinigans/GenomicsDB-Python/blob/master/INSTALL.md) for local builds and running tests.
+See [instructions](https://github.com/GenomicsDB/GenomicsDB-Python/blob/master/INSTALL.md) for local builds and running tests.

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -20,7 +20,7 @@
 #
 # Description: Base Docker file for creating PyPi Packages
 
-FROM centos:6
+FROM centos:7
 
 COPY scripts /build
 WORKDIR /build

--- a/package/README.md
+++ b/package/README.md
@@ -22,4 +22,4 @@ cd /path/to/GenomicsDB-Python/package
 ./publish_package.sh test_release
 # OR
 # ./publish_package.sh release
-```javascript
+```

--- a/package/README.md
+++ b/package/README.md
@@ -7,13 +7,13 @@ To create a GenomicsDB centos 6 docker image for publishing to PyPi.
 # This creates a base centos 6 box with python 3.6/3.7/3.8 installed. This may be built once and cached to
 # be reused again and again in Step 2
 cd /path/to/GenomicsDB-Python/package
-docker build -t all_python:centos6
+docker build -t all_python:centos6 .
 
 # Step 2
 # Create a genomicsdb image based on the image above. This will build and install GenomicsDB into /usr/local
 # and setup GENOMICSDB_HOME env appropriately. The distributable libraries should have dependencies only on
 # C runtimes, zlib and jvm.
-cd /path/to/GenomicsDB-Install
+cd /path/to/GenomicsDB/scripts
 docker build --build-arg os=all_python:centos6 --build-arg distributable_jar=true -t genomicsdb:all_python .
 
 # Step 3

--- a/package/README.md
+++ b/package/README.md
@@ -19,7 +19,7 @@ docker build --build-arg os=all_python:centos6 --build-arg distributable_jar=tru
 # Step 3
 # Build and publish genomicsdb python images
 cd /path/to/GenomicsDB-Python/package
-./publish_package.sh test_release
+./publish_package.sh test-release
 # OR
 # ./publish_package.sh release
 ```

--- a/package/publish_package.sh
+++ b/package/publish_package.sh
@@ -32,9 +32,11 @@ fi
 
 # Use centos6 based genomicsdb:all_python Docker image to create packages for 3.6/3.7/3.8
 # Current dependencies are zlib and jvm. TODO: Statically link in zlib too.
-docker-compose run -e PYTHON_VERSION="3.6" package
+echo "Building packages for Linux on CentOS 7..."
 docker-compose run -e PYTHON_VERSION="3.7" package
 docker-compose run -e PYTHON_VERSION="3.8" package
+docker-compose run -e PYTHON_VERSION="3.9" package
+echo "Building packages for Linux on CentOS 7 DONE"
 
 pushd ../
 

--- a/package/scripts/create_package.sh
+++ b/package/scripts/create_package.sh
@@ -9,7 +9,7 @@ fi
 
 pushd $HOME
 if [ ! -d GenomicsDB-Python ]; then
-  echo "GenomicsDB-Python repository not found. Cannot continue."
+  echo "Could not find GenomicsDB-Python. Cannot continue"
   exit 1
 fi
 
@@ -24,16 +24,28 @@ echo "Packaging genomicsdb for Python Version=$PYTHON_VERSION..."
 
 python$PYTHON_VERSION -m venv env-dist-$PYTHON_VERSION &&
   source env-dist-$PYTHON_VERSION/bin/activate &&
-  pip install --upgrade pip     
+  echo "Installing required dependencies for $PYTHON_VERSION..." &&
+  pip install --upgrade pip &&
+  echo "Installing wheel..." && pip install wheel && echo "Installing wheel DONE" &&
+  echo "Installing setuptools..." && pip install setuptools && echo "Installing setuptools DONE" &&
+  echo "Installing setuptools-scm..." && pip install setuptools-scm && echo "Installing setuptools-scm DONE" &&
+  echo "Installing numpy..." && pip install numpy && echo "Installing numpy DONE" &&
+  echo "Installing cython..." && pip install cython && echo "Installing cython DONE" &&
+  echo "Installing required dependencies for $PYTHON_VERSION DONE"
+
+if [[ $? -ne 0 ]]; then
+  echo "Problems installing dependencies. Cannot continue"
+  exit 1
+fi
 
 cd GenomicsDB-Python &&
-  pip install -r requirements.txt &&
   python setup.py sdist --with-libs &&
 	python setup.py bdist_wheel --with-libs --python-tag=cp${PYTHON_VERSION//./} &&
 	echo "Packaging genomicsdb for Python Version=$PYTHON_VERSION DONE" &&
 	exit 0
 
 echo "Issues encoutered while packaging genomicsdb for Python Version=$PYTHON_VERSION. Aborting."
+exit 1
 
 
 

--- a/package/scripts/install_python.sh
+++ b/package/scripts/install_python.sh
@@ -19,67 +19,69 @@ check_rc() {
 }
 
 install_python_version() {
-	# Download and extract source
-	VERSION=$1
-	wget -nv https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz &&
-		tar -xvzf Python-$VERSION.tgz
-	check_rc $?
-	pushd Python-$VERSION
-	./configure --prefix=/usr/local --with-openssl=/usr/local/ssl-$OPENSSL_VERSION --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" &&
-		make &&
-		make altinstall
-	RC=$?
-	popd
-	rm -fr Python-$VERSION Python-$VERSION.tgz
-	check_rc $RC
+  # Download and extract source
+  VERSION=$1
+  wget -nv https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz &&
+    tar -xvzf Python-$VERSION.tgz
+  check_rc $?
+  pushd Python-$VERSION
+  ./configure --prefix=/usr/local --with-openssl=/usr/local/ssl-$OPENSSL_VERSION --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" &&
+    make &&
+    make altinstall
+  RC=$?
+  popd
+  rm -fr Python-$VERSION Python-$VERSION.tgz
+  check_rc $RC
 }
 
 install_openssl() {
-	pushd /tmp
-	wget -nv https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
-		tar xzvf openssl-$OPENSSL_VERSION.tar.gz &&
-		pushd openssl-$OPENSSL_VERSION
+  pushd /tmp
+  wget -nv https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
+    tar xzvf openssl-$OPENSSL_VERSION.tar.gz &&
+    pushd openssl-$OPENSSL_VERSION
     CFLAGS=-fPIC ./config -fPIC -shared --prefix=/usr/local/ssl-$OPENSSL_VERSION &&
     make depend && make && make install
-		RC=$?
-		ln -s /usr/local/ssl-$OPENSSL_VERSION /usr/local/ssl
-		export LD_LIBRARY_PATH=/usr/local/ssl-$OPENSSL_VERSION/lib:$LD_LIBRARY_PATH
-		popd	
-		rm -fr openssl-$OPENSSL_VERSION*
-		check_rc $RC
-	popd
+    RC=$?
+    ln -s /usr/local/ssl-$OPENSSL_VERSION /usr/local/ssl
+    export LD_LIBRARY_PATH=/usr/local/ssl-$OPENSSL_VERSION/lib:$LD_LIBRARY_PATH
+    popd
+    rm -fr openssl-$OPENSSL_VERSION*
+    check_rc $RC
+  popd
 }
 
 install_devtoolset() {
-	echo "Installing devtoolset"
-	yum install -y centos-release-scl &&
-	yum install -y devtoolset-7 &&
-	source /opt/rh/devtoolset-7/enable
+  echo "Installing devtoolset"
+  yum install -y centos-release-scl &&
+  yum install -y devtoolset-7 &&
+  source /opt/rh/devtoolset-7/enable
 }
 
 sanity_test_python() {
-	PYTHON_VERSION=$1
-	pushd /tmp
-	python$PYTHON_VERSION -m venv try$PYTHON_VERSION &&
-		source try$PYTHON_VERSION/bin/activate &&
-		pip install --upgrade pip &&
-		pip install numpy &&
-		deactivate
-	RC=$?
-	rm -fr try$PYTHON_VERSION
-	popd
-	check_rc $RC
+  PYTHON_VERSION=$1
+  pushd /tmp
+  python$PYTHON_VERSION -m venv try$PYTHON_VERSION &&
+    source try$PYTHON_VERSION/bin/activate &&
+    pip install --upgrade pip &&
+    pip install numpy &&
+    pip install setuptools &&
+    pip install setuptools_scm
+    deactivate
+  RC=$?
+  rm -fr try$PYTHON_VERSION
+  popd
+  check_rc $RC
 }
+
+install
 
 yum install -y zlib-devel bzip2-devel libffi libffi-devel wget
 yum groupinstall -y "development tools"
-	
+
 install_devtoolset &&
-	install_openssl &&
-	install_python_version 3.6.10 && sanity_test_python 3.6 &&
-	install_python_version 3.7.7  && sanity_test_python 3.7 &&
-	install_python_version 3.8.3  && sanity_test_python 3.8
-
-
-
+  install_openssl &&
+  install_python_version 3.7.10  && sanity_test_python 3.7 &&
+  install_python_version 3.8.11 && sanity_test_python 3.8 &&
+  install_python_version 3.9.6 && sanity_test_python 3.9 &&
+  echo "Python versions successfully installed"
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
 	packages = find_packages(exclude=["package", "test"]),
 	keywords=['genomics', 'genomicsdb', 'variant', 'vcf', 'variant calls'],
 	include_package_data=True,
-	version = '0.0.8.04',
+	version = '0.0.8.0',
 	classifiers=[
 		'Development Status :: 3 - Alpha',
 		'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open('README.md') as f:
 
 setup(
 	name='genomicsdb',
-	description='Experimental Python Bindings to GenomicsDB',
+	description='Experimental Python Bindings for querying GenomicsDB',
 	long_description=long_description,
 	long_description_content_type='text/markdown',
 	author='GenomicsDB.org',
@@ -77,11 +77,11 @@ setup(
 	setup_requires=['cython>=0.27'],
 	install_requires=[
 		'numpy>=1.7'],
-	python_requires='>=3.6',
+	python_requires='>=3.7',
 	packages = find_packages(exclude=["package", "test"]),
 	keywords=['genomics', 'genomicsdb', 'variant', 'vcf', 'variant calls'],
 	include_package_data=True,
-	version = '0.0.7.4',
+	version = '0.0.8.04',
 	classifiers=[
 		'Development Status :: 3 - Alpha',
 		'Intended Audience :: Developers',
@@ -91,9 +91,9 @@ setup(
 		'Topic :: Software Development :: Libraries :: Python Modules',
 		'Operating System :: POSIX :: Linux',
 		'Operating System :: MacOS :: MacOS X',
-		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
 		'Programming Language :: Python :: 3.8',
+		'Programming Language :: Python :: 3.9',
 	],
 )
 


### PR DESCRIPTION
Changes are related to the following -

1. Support Python versions 3.7/3.8/3.9 for MacOS and Linux(Centos and Ubuntu) platforms.
2. `MACOSX_DEPLOYMENT_TARGET` has been moved to 11.0 because of `gcs sdk client` dependencies.
3. Move linux builds to Centos 7 as Centos 6 has been EOLed. Binaries built on Centos 7 seem to work fine on Ubuntu, but we need to keep a watch any incompatibilities.
