### PR TITLE
Build TensorFlow/Arrow/... compatible wheels on Centos 6 

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -20,9 +20,12 @@
 #
 # Description: Base Docker file for creating PyPi Packages
 
-FROM centos:7
+FROM centos:6
 
+ARG user=genomicsdb
+ARG user_id=0
+ARG group_id=0
 COPY scripts /build
 WORKDIR /build
-RUN ./install_python.sh
+RUN ./install_python.sh $user $user_id $group_id
 

--- a/package/README.md
+++ b/package/README.md
@@ -3,18 +3,21 @@ This is a repository of scripts and Docker related files to publish to PyPi.
 To create a GenomicsDB centos 6 docker image for publishing to PyPi.
 
 ```bash
+# Step 0 : Prerequisites
+In Python3 env: pip install -r requirements-dev.txt
+ 
 # Step1
-# This creates a base centos 6 box with python 3.6/3.7/3.8 installed. This may be built once and cached to
+# This creates a base centos 6 box with python 3.7/3.8/3.9 installed. This may be built once and cached to
 # be reused again and again in Step 2
 cd /path/to/GenomicsDB-Python/package
-docker build -t all_python:centos6 .
+docker build -t all_python:centos6 . --build-arg user=$USER --build-arg user_id=`id -u` --build-arg group_id=`id -g`
 
 # Step 2
 # Create a genomicsdb image based on the image above. This will build and install GenomicsDB into /usr/local
 # and setup GENOMICSDB_HOME env appropriately. The distributable libraries should have dependencies only on
-# C runtimes, zlib and jvm.
+# zlib.
 cd /path/to/GenomicsDB/scripts
-docker build --build-arg os=all_python:centos6 --build-arg distributable_jar=true -t genomicsdb:all_python .
+docker build --build-arg os=all_python:centos6 -t genomicsdb:all_python .
 
 # Step 3
 # Build and publish genomicsdb python images

--- a/package/docker-compose.yml
+++ b/package/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   package:
     image: genomicsdb:all_python
+    user: ${CURRENT_UID}
     volumes: 
-      - ..:/home/genomicsdb/GenomicsDB-Python:delegated
-    command: "/home/genomicsdb/GenomicsDB-Python/package/scripts/create_package.sh"
+      - ..:/home/${USER}/GenomicsDB-Python:delegated
+    command: "/home/${USER}/GenomicsDB-Python/package/scripts/create_package.sh"

--- a/package/publish_package.sh
+++ b/package/publish_package.sh
@@ -32,11 +32,12 @@ fi
 
 # Use centos6 based genomicsdb:all_python Docker image to create packages for 3.6/3.7/3.8
 # Current dependencies are zlib and jvm. TODO: Statically link in zlib too.
-echo "Building packages for Linux on CentOS 7..."
+echo "Building packages for Linux on CentOS 6..."
+export CURRENT_UID="$(id -u):$(id -g)"
 docker-compose run -e PYTHON_VERSION="3.7" package
 docker-compose run -e PYTHON_VERSION="3.8" package
 docker-compose run -e PYTHON_VERSION="3.9" package
-echo "Building packages for Linux on CentOS 7 DONE"
+echo "Building packages for Linux on CentOS 6 DONE"
 
 pushd ../
 

--- a/package/scripts/install_python.sh
+++ b/package/scripts/install_python.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+# Argument parsing
+PYTHON_USER=$1
+PYTHON_USER_ID=$2
+PYTHON_GROUP_ID=$3
+
 PYTHON_MAJOR=3
-OPENSSL_VERSION=1.0.2o
+OPENSSL_VERSION=1.1.1o
 
 die() {
   if [[ $# -eq 1 ]]; then
@@ -21,7 +26,7 @@ check_rc() {
 install_python_version() {
   # Download and extract source
   VERSION=$1
-  wget -nv https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz &&
+  wget $WGET_NO_CERTIFICATE -nv https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz &&
     tar -xvzf Python-$VERSION.tgz
   check_rc $?
   pushd Python-$VERSION
@@ -36,7 +41,7 @@ install_python_version() {
 
 install_openssl() {
   pushd /tmp
-  wget -nv https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
+  wget $WGET_NO_CERTIFICATE -nv https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
     tar xzvf openssl-$OPENSSL_VERSION.tar.gz &&
     pushd openssl-$OPENSSL_VERSION
     CFLAGS=-fPIC ./config -fPIC -shared --prefix=/usr/local/ssl-$OPENSSL_VERSION &&
@@ -75,8 +80,25 @@ sanity_test_python() {
 
 install
 
+# Workaround for Centos 6 being EOL'ed
+curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+yum -y install centos-release-scl
+curl https://www.getpagespeed.com/files/centos6-scl-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl.repo
+curl https://www.getpagespeed.com/files/centos6-scl-rh-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
+sed -i 's/http/https/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+WGET_NO_CERTIFICATE="--no-check-certificate"
+
 yum install -y zlib-devel bzip2-devel libffi libffi-devel wget
 yum groupinstall -y "development tools"
+
+if [[ $PYTHON_USER_ID != 0  && $PYTHON_GROUP_ID != 0 ]]; then
+  echo "groupadd -g $PYTHON_GROUP_ID genomicsdb-python"
+  echo "useradd -m $PYTHON_USER -u $PYTHON_USER_ID -g $PYTHON_GROUP_ID"
+  groupadd -g $PYTHON_GROUP_ID genomicsdb-python &&
+  useradd -m $PYTHON_USER -u $PYTHON_USER_ID -g $PYTHON_GROUP_ID
+fi
 
 install_devtoolset &&
   install_openssl &&

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     packages=find_packages(exclude=["package", "test"]),
     keywords=["genomics", "genomicsdb", "variant", "vcf", "variant calls"],
     include_package_data=True,
-    version="0.0.8.0",
+    version="0.0.8.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Build TensorFlow/Arrow/... compatible wheels on Centos 6 without including OpenSSL/CURL/uuid. This should have a corresponding change in GenomicsDB to allow for GenomicsDB builds specifically for Python bindings.

Also, made `publish_package.sh` changes to allow for building docker images from Linux as we need user/group ids to match the ones in the docker image to allow for sharing between the Linux host and the target docker image.