### PR TITLE
Support building from source distribution from PyPi better

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ git clone https://github.com/GenomicsDB/GenomicsDB-Python.git
 cd GenomicsDB-Python
 ```
 
-To build the native library with python protobuf:
+To build the native library with python protobuf
 ```
 git clone https://github.com/GenomicsDB/GenomicsDB.git -b develop GenomicsDB.native
 pushd GenomicsDB.native
@@ -19,7 +19,7 @@ popd
 popd
 ```
 
-To build and run tests in-place:
+To build the python bindings and run tests in-place:
 ```
 python3 -m venv env
 source env/bin/activate > /dev/null

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,12 @@
-recursive-include genomicsdb
+global-exclude .git*
+
+global-exclude *.pyc
+global-exclude *~
+global-exclude \#*
+global-exclude .DS_Store
+
+exclude MANIFEST.in
+
+prune package
+
+graft genomicsdb

--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@
 # GenomicsDB-Python
 Experimental Python Bindings to the native [GenomicsDB](https://github.com/GenomicsDB/GenomicsDB) library. Only queries are supported for now. For importing vcf files into GenomicsDB, use the command line tools - `vcf2genomicsdb` or `gatk GenomicsDBImport`.
 
-## Installation
-On Linux and macOS, install `genomicsdb` binary wheels from PyPi with pip:
+## Installation : Only Linux and MacOS are currently supported
+Install `genomicsdb` binary wheels from PyPi with pip:
 ```
 pip install genomicsdb
+```
+
+Or explicitly from a source distribution
+
+```
+# Download the source distribution from https://pypi.org/project/genomicsdb/#files as genomicsdb.source.tar.gz
+tar xvf genomicsdb.source.tar.gz
+cd genomicsdb-<version>
+python setup.py install
 ```
 
 ## Development

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ GENOMICSDB_LOCAL_DATA_DIR = "genomicsdb"
 
 # Specify genomicsdb install location via
 #     "--with-genomicsdb=<genomicsdb_install_path>" command line arg
-GENOMICSDB_INSTALL_PATH = os.getenv("GENOMICSDB_HOME", default="/usr/local")
+GENOMICSDB_INSTALL_PATH = os.getenv("GENOMICSDB_HOME", default="genomicsdb")
 
 copy_genomicsdb_libs = False
 copy_protobuf_definitions = False
@@ -34,6 +34,10 @@ GENOMICSDB_LIB_DIR = os.path.join(GENOMICSDB_INSTALL_PATH, "lib")
 GENOMICSDB_PROTOBUF_DIR = os.path.join(
     GENOMICSDB_INSTALL_PATH, "genomicsdb/protobuf/python"
 )
+
+if GENOMICSDB_INSTALL_PATH == "genomicsdb":
+    copy_genomicsdb_libs = False
+    copy_protobuf_definitions = False
 
 dst = os.path.join("genomicsdb/lib")
 if copy_genomicsdb_libs:
@@ -59,6 +63,12 @@ if sys.platform == "darwin":
     link_args = ["-Wl,-rpath," + dst]
 else:
     rpath = ["$ORIGIN/" + dst]
+
+dst = os.path.join("genomicsdb/include")
+if copy_genomicsdb_libs:
+    if not os.path.exists(dst):
+        os.makedirs(dst)
+    shutil.copytree(GENOMICSDB_INCLUDE_DIR, dst, dirs_exist_ok=True)
 
 dst = os.path.join("genomicsdb/protobuf")
 if copy_protobuf_definitions:


### PR DESCRIPTION
We need to include the distributable libraries from GenomicsDB with almost no external dependencies for both Linux and MacOS and the include files to support building from [source distributions in PyPi for GenomicsDB](https://pypi.org/project/genomicsdb/#files).