### PR TITLE
Get python to build locally and the created genomicsdb package installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,5 @@ TAGS
 
 #Ignore generated cpp files
 src/genomicsdb.cpp
-genomicsdb_data/lib
+genomicsdb/lib
+genomicsdb/include

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ help:
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 	rm -fr genomicsdb/lib/lib*
+	rm -fr genomicsdb/include/*
+	rm genomicsdb/genomicsdb.cpython*so
 	rm -fr genomicsdb/protobuf/genomicsdb*.py
 
 clean-build: ## remove build artifacts

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 	rm -fr genomicsdb/lib/lib*
 	rm -fr genomicsdb/include/*
-	rm genomicsdb/genomicsdb.cpython*so
+	rm -f genomicsdb/genomicsdb.cpython*so
 	rm -fr genomicsdb/protobuf/genomicsdb*.py
 
 clean-build: ## remove build artifacts

--- a/genomicsdb/__init__.py
+++ b/genomicsdb/__init__.py
@@ -3,9 +3,9 @@ import os
 import sys
 
 if sys.platform == "darwin":
-    ctypes.CDLL(os.path.join("lib", "libtiledbgenomicsdb.dylib"))
+    ctypes.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib/libtiledbgenomicsdb.dylib"))
 else:
-    ctypes.CDLL(os.path.join("lib", "libtiledbgenomicsdb.so"))
+    ctypes.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib/libtiledbgenomicsdb.so"))
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 from .genomicsdb import *

--- a/genomicsdb/__init__.py
+++ b/genomicsdb/__init__.py
@@ -1,2 +1,11 @@
+import ctypes
+import os
+import sys
+
+if sys.platform == "darwin":
+    ctypes.CDLL(os.path.join("lib", "libtiledbgenomicsdb.dylib"))
+else:
+    ctypes.CDLL(os.path.join("lib", "libtiledbgenomicsdb.so"))
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 from .genomicsdb import *

--- a/package/scripts/install_python_local.sh
+++ b/package/scripts/install_python_local.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+VERSION=${VERSION:-3.10.8}
+PREFIX=${PREFIX:-/usr/local}
+OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR:-/usr/lib64}
+
+wget -nv https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz
+tar -xvzf Python-$VERSION.tgz
+
+# Dependencies
+sudo yum install -y bzip2-devel libffi libffi-devel
+sudo yum install readline-devel # needed for command history from interpreter
+
+pushd Python-$VERSION
+./configure --prefix=$PREFIX --with-openssl=$OPENSSL_ROOT_DIR --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" --enable-optimizations --disable-test-modules
+make -j8
+make altinstall
+popd
+
+rm -fr Python-$VERSION*


### PR DESCRIPTION
Changed __init.py__ to explicitly load the  native GenomicsDB library as the previous implicit load was not loading it. Also added a few helper scripts to install multiple python versions locally.