### PR TITLE
Swap to centos 7 image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -20,7 +20,8 @@
 #
 # Description: Base Docker file for creating PyPi Packages
 
-FROM ghcr.io/genomicsdb/genomicsdb:centos_6_prereqs
+#FROM ghcr.io/genomicsdb/genomicsdb:centos_6_prereqs
+FROM genomicsdb:centos_7_prereqs
 
 ARG user=genomicsdb
 ARG user_id=0

--- a/package/scripts/install_genomicsdb.sh
+++ b/package/scripts/install_genomicsdb.sh
@@ -98,6 +98,7 @@ git clone https://github.com/GenomicsDB/GenomicsDB.git --recursive -b $BRANCH Ge
 
 pushd GenomicsDB
 echo "Starting GenomicsDB build"
+export CMAKE_PREFIX_PATH=/usr/local/ssl
 DOCKER_BUILD=true ./scripts/install_genomicsdb.sh $USER /usr/local true python false
 popd
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
     packages=find_packages(exclude=["package", "test"]),
     keywords=["genomics", "genomicsdb", "variant", "vcf", "variant calls"],
     include_package_data=True,
-    version="0.0.8.18",
+    version="0.0.8.20",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Note: The `genomicsdb:centos_7_prereqs` image used in the Dockerfile was made by editing the image in `Dockerfile.release_prereqs` from `centos:6` to `centos:7` in the [GenomicsDB](https://github.com/GenomicsDB/GenomicsDB) repo and built using `docker build -t genomicsdb:centos_7_prereqs -f Dockerfile.release_prereqs .` 

Then I ran ```docker build -t genomicsdb:python . --build-arg user=$USER --build-arg user_id=`id -u` --build-arg group_id=`id -g` --build-arg genomicsdb_branch=master``` which produced the following error: `/usr/lib64/libcrypto.so.10: error adding symbols: DSO missing from command line` during the `Linking CXX executable api_tests` step.

And after stopping and starting the container the build completed without errors.