### PR TITLE
Move to using GenomicsDB master branch and bump release version

### DIFF
--- a/package/scripts/install_prereqs_for_wheels.sh
+++ b/package/scripts/install_prereqs_for_wheels.sh
@@ -34,7 +34,7 @@ install_genomicsdb_for_mac() {
     export MACOSX_DEPLOYMENT_TARGET=12.1
     export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
     rm -fr $GENOMICSDB_DIR
-    git clone https://github.com/GenomicsDB/GenomicsDB.git -b develop $GENOMICSDB_DIR
+    git clone https://github.com/GenomicsDB/GenomicsDB.git $GENOMICSDB_DIR
     pushd $GENOMICSDB_DIR
     echo "Starting GenomicsDB build"
     mkdir build && cd build &&
@@ -54,7 +54,7 @@ install_genomicsdb_for_centos7() {
     INSTALL_PREFIX=/usr/local
     export OPENSSL_ROOT_DIR=$INSTALL_PREFIX
     export LD_LIBRARY_PATH=$INSTALL_PREFIX/lib64:$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH
-    git clone https://github.com/GenomicsDB/GenomicsDB.git -b develop GenomicsDB-build
+    git clone https://github.com/GenomicsDB/GenomicsDB.git GenomicsDB-build
     pushd GenomicsDB-build
     echo "Starting GenomicsDB build"
     mkdir build && cd build &&

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     packages=find_packages(exclude=["package", "test"]),
     keywords=["genomics", "genomicsdb", "variant", "vcf", "variant calls"],
     include_package_data=True,
-    version="0.0.9.4",
+    version="0.0.9.3",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Use master branch for building the GenomicsDB shared library and move hardcoded release version in setup.py to `0.0.9.3` while we figure out #36.