### PR TITLE
Read requirements.txt into setup.py and delocate cython library manua…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ release: dist ## package and upload a release
 dist: ## builds source and wheel package
 	python setup.py sdist --with-libs
 	python setup.py bdist_wheel --with-libs
+	package/scripts/delocate_wheel_local.sh
 	ls -l dist
 
 install: ## install the package to the active Python's site-packages

--- a/package/scripts/delocate_wheel_local.sh
+++ b/package/scripts/delocate_wheel_local.sh
@@ -1,0 +1,56 @@
+#
+# delocate_wheel_local.sh
+#
+# The MIT License (MIT)
+# Copyright (c) 2024 dātma, inc™
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Description: Script to delocate wheel by sanitizing native library paths
+#
+
+#!/bin/bash
+
+if [[ $(uname) == "Linux" ]]; then
+  exit 0
+fi
+
+pushd dist
+
+mkdir genomicsdb
+for WHEEL in $(ls *.whl)
+do
+  echo "delocating WHEEL=$WHEEL"
+  VERSION=$(echo $WHEEL | grep -o cp... | head -n1 | cut -c 3-5)
+  LIB=genomicsdb.cpython-$VERSION-darwin.so
+  CYTHON_LIB=genomicsdb/$LIB
+  rm -fr $CYTHON_LIB
+  unzip -j $WHEEL $CYTHON_LIB > /dev/null
+  mv $LIB genomicsdb
+  ls $CYTHON_LIB > /dev/null
+  if [[ $? != 0 ]]; then
+    echo "Could not find CYTHON_LIB=$CYTHON_LIB"
+    exit 1
+  fi
+  install_name_tool -change @rpath/libtiledbgenomicsdb.1.dylib @loader_path/lib/libtiledbgenomicsdb.1.dylib $CYTHON_LIB
+  otool -L $CYTHON_LIB
+  zip $WHEEL $CYTHON_LIB
+done
+rm -fr genomicsdb
+
+popd

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ GENOMICSDB_LOCAL_DATA_DIR = "genomicsdb"
 GENOMICSDB_INSTALL_PATH = os.getenv("GENOMICSDB_HOME", default="genomicsdb")
 copy_genomicsdb_libs = False
 copy_protobuf_definitions = False
-with_version = "0.0.9.3"
+with_version = "0.0.9.14"
 
 args = sys.argv[:]
 for arg in args:
@@ -143,6 +143,9 @@ genomicsdb_extension = Extension(
 with open("README.md") as f:
     long_description = f.read()
 
+with open("requirements.txt") as f:
+    install_requirements = f.readlines()
+
 setup(
     name="genomicsdb",
     description="Experimental Python Bindings for querying GenomicsDB",
@@ -156,7 +159,7 @@ setup(
     ext_modules=[genomicsdb_extension],
     zip_safe=False,
     setup_requires=["cython>=0.27"],
-    install_requires=["numpy>=1.19.5", "pandas", "protobuf>=4.21.1"],
+    install_requires=install_requirements,
     python_requires=">=3.9",
     packages=find_packages(exclude=["package", "test"]),
     keywords=["genomics", "genomicsdb", "variant", "vcf", "variant calls"],


### PR DESCRIPTION
1. Use `requirements.txt` as one source to specify requirements, so use that in setup.py - ran into the issue with `numpy 2` incompatibilities downstream because setup.py was not updated although requirements.txt was.
2. Delocate cython library manually(MacOS only) to be used only with local builds and installs, `cibuildwheel` does that for the release builds. 