### PR TITLE
Add CXXFLAGS for cython

### DIFF
--- a/.github/scripts/install_prereqs.sh
+++ b/.github/scripts/install_prereqs.sh
@@ -216,6 +216,6 @@ if [[ $1 == "release" ]]; then
     fi
     cmake .. $CMAKE_ARCH_ARG -DBUILD_NANOARROW=1 -DPROTOBUF_ROOT_DIR=./protobuf -DGCSSDK_ROOT_DIR=./gcssdk -DAWSSDK_ROOT_DIR=./awssdk -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DBUILD_EXAMPLES=False -DDISABLE_MPI=True -DDISABLE_OPENMP=True -DDISABLE_TOOLS=True -DDISABLE_EXAMPLES=True -DDISABLE_TESTING=True -DOPENSSL_USE_STATIC_LIBS=True &&
     make -j4 || rebuild && $SUDO make install &&
-    if [[ -f $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so ]]; then nm $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so | grep Processor fi
+    if [[ -f $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so ]]; then nm $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so | grep Processor; fi
     popd && popd
 fi

--- a/.github/scripts/install_prereqs.sh
+++ b/.github/scripts/install_prereqs.sh
@@ -216,6 +216,5 @@ if [[ $1 == "release" ]]; then
     fi
     cmake .. $CMAKE_ARCH_ARG -DBUILD_NANOARROW=1 -DPROTOBUF_ROOT_DIR=./protobuf -DGCSSDK_ROOT_DIR=./gcssdk -DAWSSDK_ROOT_DIR=./awssdk -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DBUILD_EXAMPLES=False -DDISABLE_MPI=True -DDISABLE_OPENMP=True -DDISABLE_TOOLS=True -DDISABLE_EXAMPLES=True -DDISABLE_TESTING=True -DOPENSSL_USE_STATIC_LIBS=True &&
     make -j4 || rebuild && $SUDO make install &&
-    if [[ -f $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so ]]; then nm $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so | grep Processor; fi
     popd && popd
 fi

--- a/.github/scripts/install_prereqs.sh
+++ b/.github/scripts/install_prereqs.sh
@@ -216,5 +216,6 @@ if [[ $1 == "release" ]]; then
     fi
     cmake .. $CMAKE_ARCH_ARG -DBUILD_NANOARROW=1 -DPROTOBUF_ROOT_DIR=./protobuf -DGCSSDK_ROOT_DIR=./gcssdk -DAWSSDK_ROOT_DIR=./awssdk -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DBUILD_EXAMPLES=False -DDISABLE_MPI=True -DDISABLE_OPENMP=True -DDISABLE_TOOLS=True -DDISABLE_EXAMPLES=True -DDISABLE_TESTING=True -DOPENSSL_USE_STATIC_LIBS=True &&
     make -j4 || rebuild && $SUDO make install &&
+    if [[ -f $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so ]]; then nm $INSTALL_PREFIX/lib/libtiledbgenomicsdb.so | grep Processor fi
     popd && popd
 fi

--- a/setup.py
+++ b/setup.py
@@ -108,9 +108,11 @@ if copy_protobuf_definitions:
                 file.write(replaced_contents)
 
 os.environ["CFLAGS"] = "-DUSE_NANOARROW=1"
+os.environ["CXXFLAGS"] = "-DUSE_NANOARROW=1"
 
 if "OSX_ARCH" in os.environ:
     os.environ["CFLAGS"] = "-arch " + os.environ["OSX_ARCH"]
+    os.environ["CXXFLAGS"] = "-arch " + os.environ["OSX_ARCH"]
 
 EXTRA_COMPILE_ARGS=["-std=c++20"]
 if "CXX" in os.environ and os.environ["CXX"].find("devtoolset-11") > 0:


### PR DESCRIPTION
The cython compiler does not use `CFLAGS` with c++ in its latest version, only `CXXFLAGS`. So, adding `CXXFLAGS` in addition to `CFLAGS` for cython.
@mlathara, see published genomicsdb 0.0.9.16 for the arrow stream changes.