### PR TITLE
Support sample specification in addition to intervals to the tool.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,6 @@ options:
                         	1. -i/--interval and -I/--interval-list are mutually exclusive 
                         	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
   -I INTERVAL_LIST, --interval-list INTERVAL_LIST
-                        NOT YET IMPLEMENTED
                         genomic intervals listed in a file over which to operate.
                         The intervals should be specified in the <CONTIG>:<START>-<END> format, with START and END optional one interval per line. 
                         Note: 
@@ -42,7 +41,6 @@ options:
                         	1. -s/--sample and -S/--sample-list are mutually exclusive 
                         	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
   -S SAMPLE_LIST, --sample-list SAMPLE_LIST
-                        NOT YET IMPLEMENTED
                         sample file containing list of samples, one sample per line, to operate upon. 
                         Note: 
                         	1. -s/--sample and -S/--sample-list are mutually exclusive 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,35 +1,77 @@
 ## GenomicsDB simple query tool
 
-Simple GenomicsDB query tool, given a workspace and genomic intervals of the form `<CONTIG>:<START>-<END>`.  The intervals at a minimum need to have the contig specified, start and end are optional. e.g chr1:100-1000, chr1:100 and chr1 are all valid. Start defaults to 1 if not specified and end defaults to the length of the contig if not specified.
+Simple GenomicsDB query tool `genomicsdb_query`, given a workspace and genomic intervals of the form `<CONTIG>:<START>-<END>`.  The intervals at a minimum need to have the contig specified, start and end are optional. e.g chr1:100-1000, chr1:100 and chr1 are all valid. Start defaults to 1 if not specified and end defaults to the length of the contig if not specified.
 
 Assumption : The workspace should have been created with the `vcf2genomicsdb` tool or with `gatk GenomicsDBImport` and should exist.
-
-For ease of use, open run.sh and change the `WORKSPACE`, `INTERVALS` and optionally `FILTER` variables to what is desired before invoking it. Variables `VIDMAP_FILE` and `LOADER_FILE` need to be set only if they are not in the workspace. run.sh calls genomicsdb_query, the tool does the querying of the workspace for the intervals specified and outputs one csv file per input interval.
 
 ``` 
 ~/GenomicsDB-Python/examples: ./genomicsdb_query --help
 usage: query [options]
 
-GenomicsDB simple query
+GenomicsDB simple query with samples/intervals/filter as inputs
 
 options:
   -h, --help            show this help message and exit
   --version             print GenomicsDB native library version and exit
   -w WORKSPACE, --workspace WORKSPACE
-                        URL to GenomicsDB workspace, e.g. -w my_workspace or -w az://my_container/my_workspace or -w s3://my_bucket/my_workspace or -w
-                        gs://my_bucket/my_workspace
+                        URL to GenomicsDB workspace, e.g. -w my_workspace or -w az://my_container/my_workspace or -w s3://my_bucket/my_workspace or -w gs://my_bucket/my_workspace
   -v VIDMAP, --vidmap VIDMAP
                         Optional - URL to vid mapping file. Defaults to vidmap.json in workspace
+  -c CALLSET, --callset CALLSET
+                        Optional - URL to callset mapping file. Defaults to callset.json in workspace
   -l LOADER, --loader LOADER
                         Optional - URL to loader file. Defaults to loader.json in workspace
+  --list-samples        List samples ingested into the workspace and exit
+  --list-contigs        List contigs for the ingested samples in the workspace and exit
+  -i INTERVAL, --interval INTERVAL
+                        genomic intervals over which to operate. The intervals should be specified in the <CONTIG>:<START>-<END> format with START and END optional.
+                        This argument may be specified 0 or more times e.g -i chr1:1-10000 -i chr2 -i chr3:1000. 
+                        Note: 
+                        	1. -i/--interval and -I/--interval-list are mutually exclusive 
+                        	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
+  -I INTERVAL_LIST, --interval-list INTERVAL_LIST
+                        NOT YET IMPLEMENTED
+                        genomic intervals listed in a file over which to operate.
+                        The intervals should be specified in the <CONTIG>:<START>-<END> format, with START and END optional one interval per line. 
+                        Note: 
+                        	1. -i/--interval and -I/--interval-list are mutually exclusive 
+                        	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
+  -s SAMPLE, --sample SAMPLE
+                        sample names over which to operate. This argument may be specified 0 or more times e.g -s HG00097 -s HG00090. 
+                        Note: 
+                        	1. -s/--sample and -S/--sample-list are mutually exclusive 
+                        	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
+  -S SAMPLE_LIST, --sample-list SAMPLE_LIST
+                        NOT YET IMPLEMENTED
+                        sample file containing list of samples, one sample per line, to operate upon. 
+                        Note: 
+                        	1. -s/--sample and -S/--sample-list are mutually exclusive 
+                        	2. either samples and/or intervals using -i/-I/-s/-S options has to be specified
   -f FILTER, --filter FILTER
                         Optional - genomic filter expression for the query, e.g. 'ISHOMREF' or 'ISHET' or 'REF == "G" && resolve(GT, REF, ALT) &= "T/T" && ALT |= "T"'
-  -L INTERVAL, --interval INTERVAL
-                        One or more genomic intervals over which to operate. This argument may be specified 1 or more times e.g -L chr1:1-10000 -L 1:100001 -L chr2 -L chr3:1000
+  -t {csv,json}, --output-type {csv,json}
+                        Optional - specify type of output for the query. (default: csv)
   -o OUTPUT, --output OUTPUT
-                        a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv
+                        a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv/.json
+```
+
+Run `genomicsdb_query` with the -w and --list-samples/--list-contigs to figure out legitimate samples and contigs over which the query can operate. These can be used with the --samples/--intervals options later to run the actual query.
 
 ```
+~/GenomicsDB-Python/examples: ./genomicsdb_query --list-contigs -w my_workspace
+1
+2
+...
+MT
+X
+Y
+~/GenomicsDB-Python/examples: ./genomicsdb_query --list-samples -w my_workspace
+HG00096
+HG00097
+HG00099
+```
+
+Example actual query :
 
 ```
 ~/GenomicsDB-Python/examples: ./genomicsdb_query -w my_workspace  -L 1:100-100000 -L 1:100001 -L 2 -L 3 -f ISHOMREF -o query_output
@@ -48,3 +90,6 @@ Starting genomicsdb_query for workspace(my_workspace) and intervals(['1:100-1000
 query_output_1-100-100000.csv  query_output_1-100001.csv      query_output_2.csv
 
 ```
+
+
+For ease of use, open run.sh and change the `WORKSPACE`, `INTERVALS` and other commented out variables to what is desired before invoking it. Variables `VIDMAP_FILE` and `LOADER_FILE` need to be set only if they are not in the workspace. run.sh calls genomicsdb_query, the tool does the querying of the workspace for the intervals specified and outputs one csv file per input interval.

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -60,7 +60,7 @@ def generate_output_filename(output, interval, idx):
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="query", description="GenomicsDB simple query", usage="%(prog)s [options]")
+    parser = argparse.ArgumentParser(prog="query", description="GenomicsDB simple query with samples/intervals/filter as inputs", formatter_class=argparse.RawTextHelpFormatter, usage="%(prog)s [options]")
     parser.add_argument("--version", action="store_true", help="print GenomicsDB native library version and exit")
     parser.add_argument(
         "-w",
@@ -76,14 +76,40 @@ def main():
         help="Optional - URL to vid mapping file. Defaults to vidmap.json in workspace",
     )
     parser.add_argument(
+        "-c",
+        "--callset",
+        required=False,
+        help="Optional - URL to callset mapping file. Defaults to callset.json in workspace",
+    )
+    parser.add_argument(
         "-l", "--loader", required=False, help="Optional - URL to loader file. Defaults to loader.json in workspace"
     )
     parser.add_argument(
-        "-L",
+        "-i",
         "--interval",
         action="append",
-        required=True,
-        help="One or more genomic intervals over which to operate. This argument may be specified 1 or more times e.g -L chr1:1-10000 -L chr2 -L chr3:1000",
+        required=False,
+        help="genomic intervals over which to operate. The intervals should be specified in the <CHROM>:<START>-<END> format with START and END optional. This argument may be specified 0 or more times e.g -i chr1:1-10000 -i chr2 -i chr3:1000. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+    )
+    parser.add_argument(
+        "-I",
+        "--interval-list",
+        action="append",
+        required=False,
+        help="genomic intervals listed in a file over which to operate. The intervals should be specified in the <CHROM>:<START>-<END> format, with START and END optional one interval per line. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+    )
+    parser.add_argument(
+        "-s",
+        "--sample",
+        action="append",
+        required=False,
+        help="sample names over which to operate. This argument may be specified 0 or more times e.g -s HG00097 -s HG00090. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+    )
+    parser.add_argument(
+        "-S",
+        "--sample-list",
+        required=False,
+        help="sample file containing list of samples, one sample per line, to operate upon. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-f",
@@ -92,10 +118,16 @@ def main():
         help="Optional - genomic filter expression for the query, e.g. 'ISHOMREF' or 'ISHET' or 'REF == \"G\" && resolve(GT, REF, ALT) &= \"T/T\" && ALT |= \"T\"'",
     )
     parser.add_argument(
+        "-t",
+        "--output-type",
+        required=False,
+        help="Optional - query output could be specified as either 'csv' or 'json'. Defaults to 'csv'",
+    )
+    parser.add_argument(
         "-o",
         "--output",
         required=True,
-        help="a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv",
+        help="a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv/.json",
     )
 
     args = parser.parse_args()
@@ -116,6 +148,7 @@ def main():
         raise RuntimeError(f"vidmap({vidmap_file}) or loader({loader_file}) not found")
     intervals = args.interval
     filter = args.filter
+    output_type = args.output_type
     output = args.output
 
     # parse vidmap.json
@@ -184,8 +217,13 @@ def main():
             contig_interval.begin = start
             contig_interval.end = end
             query_config.query_contig_intervals.extend([contig_interval])
-            df = gdb.query_variant_calls(query_protobuf=query_config, flatten_intervals=True)
-            df.to_csv(generate_output_filename(output, interval, idx), index=False)
+            if output_type == "csv":
+                df = gdb.query_variant_calls(query_protobuf=query_config, flatten_intervals=True)
+                df.to_csv(generate_output_filename(output, output_type, interval, idx), index=False)
+            elif output_type == "json":
+                json = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.ALL)
+                with open(generate_output_filename(output, output_type, interval, idx, "wb")) as f:
+                    f.write(json)
 
     print(f"DONE genomicsdb_query for workspace({workspace}) and intervals({intervals})")
 

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -28,26 +28,52 @@
 
 import argparse
 import json
+import os
 import re
 import sys
 
 import genomicsdb
+from genomicsdb import json_output_mode
 from genomicsdb.protobuf import genomicsdb_coordinates_pb2 as query_coords
 from genomicsdb.protobuf import genomicsdb_export_config_pb2 as query_pb
 
 
-def parse_vidmap_json(vidmap_file, intervals):
+def parse_vidmap_json(vidmap_file, intervals=None):
+    if type(intervals) == str:
+        is_file = True
+    else:
+        is_file = False
     contigs_map = {}
     vidmap = json.loads(genomicsdb.read_entire_file(vidmap_file))
     contigs = vidmap["contigs"]
-    all_intervals = not intervals or False
-    if all_intervals:
+    if intervals and is_file:
+        with open(intervals) as file:
+            intervals = [line.rstrip() for line in file]
+    all_intervals = not intervals
+    if not intervals:
         intervals = []
     for contig in contigs:
         contigs_map[contig["name"]] = contig
         if all_intervals:
             intervals.append(contig["name"])
     return contigs_map, intervals
+
+
+def parse_callset_json(callset_file, samples=None):
+    if type(samples) == str:
+        is_file = True
+    else:
+        is_file = False
+    callset = json.loads(genomicsdb.read_entire_file(callset_file))
+    callsets = callset["callsets"]
+    if samples and is_file:
+        with open(samples) as file:
+            samples = [line.rstrip() for line in file]
+    if not samples:
+        samples = []
+        for callset in callsets:
+            samples.append(callset["sample_name"])
+    return samples
 
 
 def genomicsdb_connect(workspace, callset_file, vidmap_file, filter):
@@ -70,12 +96,17 @@ def setup_gdb():
         formatter_class=argparse.RawTextHelpFormatter,
         usage="%(prog)s [options]",
     )
-    parser.add_argument("--version", action="store_true", help="print GenomicsDB native library version and exit")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=genomicsdb.version(),
+        help="print GenomicsDB native library version and exit",
+    )
     parser.add_argument(
         "-w",
         "--workspace",
         required=True,
-        help="URL to GenomicsDB workspace, e.g. -w my_workspace or -w az://my_container/my_workspace"
+        help="URL to GenomicsDB workspace \ne.g. -w my_workspace or -w az://my_container/my_workspace"
         + " or -w s3://my_bucket/my_workspace or -w gs://my_bucket/my_workspace",
     )
     parser.add_argument(
@@ -107,9 +138,8 @@ def setup_gdb():
     parser.add_argument(
         "-I",
         "--interval-list",
-        action="append",
         required=False,
-        help="NOT YET IMPLEMENTED\ngenomic intervals listed in a file over which to operate.\nThe intervals should be specified in the <CONTIG>:<START>-<END> format, with START and END optional one interval per line. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+        help="genomic intervals listed in a file over which to operate.\nThe intervals should be specified in the <CONTIG>:<START>-<END> format, with START and END optional one interval per line. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-s",
@@ -122,7 +152,7 @@ def setup_gdb():
         "-S",
         "--sample-list",
         required=False,
-        help="NOT YET IMPLEMENTED\nsample file containing list of samples, one sample per line, to operate upon. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+        help="sample file containing list of samples, one sample per line, to operate upon. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-f",
@@ -145,11 +175,8 @@ def setup_gdb():
     )
 
     args = parser.parse_args()
-    if args.version:
-        print(f"GenomicsDB native library version={genomicsdb.version()}")
-        sys.exit(0)
 
-    workspace = args.workspace
+    workspace = os.path.abspath(args.workspace)
     if not genomicsdb.is_file(workspace + "/__tiledb_workspace.tdb"):
         raise RuntimeError(f"workspace({workspace}) not found")
     callset_file = args.callset
@@ -167,24 +194,32 @@ def setup_gdb():
         or not genomicsdb.is_file(loader_file)
     ):
         raise RuntimeError(f"callset({callset_file}) vidmap({vidmap_file}) or loader({loader_file}) not found")
-    if args.list_samples:
-        callset = json.loads(genomicsdb.read_entire_file(callset_file))
-        callsets = callset["callsets"]
-        samples = []
-        for callset in callsets:
-            samples.append(callset["sample_name"])
-        print(*samples, sep="\n")
-        sys.exit(0)
-    contigs_map, intervals = parse_vidmap_json(vidmap_file, args.interval)
+
     if args.list_contigs:
+        _, intervals = parse_vidmap_json(vidmap_file)
         print(*intervals, sep="\n")
         sys.exit(0)
+
+    if args.list_samples:
+        samples = parse_callset_json(callset_file)
+        print(*samples, sep="\n")
+        sys.exit(0)
+
+    intervals = args.interval
+    interval_list = args.interval_list
     samples = args.sample
-    # parse loader.json
+    sample_list = args.sample_list
+    if not intervals and not samples and not interval_list and not sample_list:
+        raise RuntimeError(
+            "Specify at least one of either -i/-interval -I/--interval-list -s/--sample -S/--sample-list has to be specified"
+        )
+
+    contigs_map, intervals = parse_vidmap_json(vidmap_file, intervals or interval_list)
+    samples = parse_callset_json(callset_file, samples or sample_list)
+
+    # parse loader.json for partitions
     loader = json.loads(genomicsdb.read_entire_file(loader_file))
     partitions = loader["column_partitions"]
-    if not samples and not intervals:
-        raise RuntimeError("Specify at least one of either -i/-interval -s/--sample has to be specified")
 
     gdb = genomicsdb_connect(workspace, callset_file, vidmap_file, args.filter)
 
@@ -241,7 +276,7 @@ def main():
                 continue
             if partition["workspace"] != workspace:
                 raise RuntimeError(
-                    f"Partiton workspaces({partition['workspace']} different from input workspace{workspace} not supported"
+                    f"Partiton workspaces({partition['workspace']} different from input workspace({workspace}) not supported"
                 )
             arrays.append(partition["array_name"])
 
@@ -270,7 +305,7 @@ def main():
                 df.to_csv(generate_output_filename(output, output_type, interval, idx), index=False)
             elif output_type == "json":
                 json_output = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.ALL)
-                with open(generate_output_filename(output, output_type, interval, idx, "wb")) as f:
+                with open(generate_output_filename(output, output_type, interval, idx), "wb") as f:
                     f.write(json_output)
 
     print(f"genomicsdb_query for workspace({workspace}) and intervals({intervals}) completed successfully")

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -70,9 +70,7 @@ def parse_callset_json(callset_file, samples=None):
         with open(samples) as file:
             samples = [line.rstrip() for line in file]
     if not samples:
-        samples = []
-        for callset in callsets:
-            samples.append(callset["sample_name"])
+        samples = [callset for callset in callsets]
     return samples
 
 

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -35,32 +35,41 @@ import genomicsdb
 from genomicsdb.protobuf import genomicsdb_coordinates_pb2 as query_coords
 from genomicsdb.protobuf import genomicsdb_export_config_pb2 as query_pb
 
-interval_pattern = re.compile(r"(.*):(.*)-(.*)|(.*):(.*)|(.*)")
+
+def parse_vidmap_json(vidmap_file, intervals):
+    contigs_map = {}
+    vidmap = json.loads(genomicsdb.read_entire_file(vidmap_file))
+    contigs = vidmap["contigs"]
+    all_intervals = not intervals or False
+    if all_intervals:
+        intervals = []
+    for contig in contigs:
+        contigs_map[contig["name"]] = contig
+        if all_intervals:
+            intervals.append(contig["name"])
+    return contigs_map, intervals
 
 
-def parse_interval(interval: str):
-    result = re.match(interval_pattern, interval)
-    if result:
-        length = len(result.groups())
-        if length == 6:
-            if result.group(1) and result.group(2) and result.group(3):
-                return result.group(1), int(result.group(2)), int(result.group(3))
-            elif result.group(4) and result.group(5):
-                return result.group(4), int(result.group(5)), None
-            elif result.group(6):
-                return result.group(6), 1, None
-    raise RuntimeError(f"Interval {interval} could not be parsed")
+def genomicsdb_connect(workspace, callset_file, vidmap_file, filter):
+    export_config = query_pb.ExportConfiguration()
+    export_config.workspace = workspace
+    export_config.attributes.extend(["REF", "ALT", "GT"])
+    export_config.vid_mapping_file = vidmap_file
+    export_config.callset_mapping_file = callset_file
+    export_config.bypass_intersecting_intervals_phase = False
+    export_config.enable_shared_posixfs_optimizations = True
+    if filter:
+        export_config.query_filter = filter
+    return genomicsdb.connect_with_protobuf(export_config)
 
 
-def generate_output_filename(output, interval, idx):
-    output_filename = f"{output}_{interval.replace(':', '-')}"
-    if idx > 0:
-        output_filename = output_filename + f"_{idx}"
-    return output_filename + ".csv"
-
-
-def main():
-    parser = argparse.ArgumentParser(prog="query", description="GenomicsDB simple query with samples/intervals/filter as inputs", formatter_class=argparse.RawTextHelpFormatter, usage="%(prog)s [options]")
+def setup_gdb():
+    parser = argparse.ArgumentParser(
+        prog="query",
+        description="GenomicsDB simple query with samples/intervals/filter as inputs",
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage="%(prog)s [options]",
+    )
     parser.add_argument("--version", action="store_true", help="print GenomicsDB native library version and exit")
     parser.add_argument(
         "-w",
@@ -84,19 +93,23 @@ def main():
     parser.add_argument(
         "-l", "--loader", required=False, help="Optional - URL to loader file. Defaults to loader.json in workspace"
     )
+    parser.add_argument("--list-samples", action="store_true", help="List samples ingested into the workspace and exit")
+    parser.add_argument(
+        "--list-contigs", action="store_true", help="List contigs for the ingested samples in the workspace and exit"
+    )
     parser.add_argument(
         "-i",
         "--interval",
         action="append",
         required=False,
-        help="genomic intervals over which to operate. The intervals should be specified in the <CHROM>:<START>-<END> format with START and END optional. This argument may be specified 0 or more times e.g -i chr1:1-10000 -i chr2 -i chr3:1000. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+        help="genomic intervals over which to operate. The intervals should be specified in the <CONTIG>:<START>-<END> format with START and END optional.\nThis argument may be specified 0 or more times e.g -i chr1:1-10000 -i chr2 -i chr3:1000. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-I",
         "--interval-list",
         action="append",
         required=False,
-        help="genomic intervals listed in a file over which to operate. The intervals should be specified in the <CHROM>:<START>-<END> format, with START and END optional one interval per line. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+        help="NOT YET IMPLEMENTED\ngenomic intervals listed in a file over which to operate.\nThe intervals should be specified in the <CONTIG>:<START>-<END> format, with START and END optional one interval per line. \nNote: \n\t1. -i/--interval and -I/--interval-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-s",
@@ -109,7 +122,7 @@ def main():
         "-S",
         "--sample-list",
         required=False,
-        help="sample file containing list of samples, one sample per line, to operate upon. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
+        help="NOT YET IMPLEMENTED\nsample file containing list of samples, one sample per line, to operate upon. \nNote: \n\t1. -s/--sample and -S/--sample-list are mutually exclusive \n\t2. either samples and/or intervals using -i/-I/-s/-S options has to be specified",
     )
     parser.add_argument(
         "-f",
@@ -120,14 +133,15 @@ def main():
     parser.add_argument(
         "-t",
         "--output-type",
-        required=False,
-        help="Optional - query output could be specified as either 'csv' or 'json'. Defaults to 'csv'",
+        choices=["csv", "json"],
+        default="csv",
+        help="Optional - specify type of output for the query (default: %(default)s)",
     )
     parser.add_argument(
         "-o",
         "--output",
-        required=True,
-        help="a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv/.json",
+        default="query_output",
+        help="a prefix filename to csv outputs from the tool. The filenames will be suffixed with the interval and .csv/.json (default: %(default)s)",
     )
 
     args = parser.parse_args()
@@ -138,40 +152,71 @@ def main():
     workspace = args.workspace
     if not genomicsdb.is_file(workspace + "/__tiledb_workspace.tdb"):
         raise RuntimeError(f"workspace({workspace}) not found")
+    callset_file = args.callset
+    if not callset_file:
+        callset_file = workspace + "/callset.json"
     vidmap_file = args.vidmap
     if not vidmap_file:
         vidmap_file = workspace + "/vidmap.json"
     loader_file = args.loader
     if not loader_file:
         loader_file = workspace + "/loader.json"
-    if not genomicsdb.is_file(vidmap_file) or not genomicsdb.is_file(loader_file):
-        raise RuntimeError(f"vidmap({vidmap_file}) or loader({loader_file}) not found")
-    intervals = args.interval
-    filter = args.filter
-    output_type = args.output_type
-    output = args.output
-
-    # parse vidmap.json
-    contigs_map = {}
-    vidmap = json.loads(genomicsdb.read_entire_file(vidmap_file))
-    contigs = vidmap["contigs"]
-    for contig in contigs:
-        contigs_map[contig["name"]] = contig
-
+    if (
+        not genomicsdb.is_file(callset_file)
+        or not genomicsdb.is_file(vidmap_file)
+        or not genomicsdb.is_file(loader_file)
+    ):
+        raise RuntimeError(f"callset({callset_file}) vidmap({vidmap_file}) or loader({loader_file}) not found")
+    if args.list_samples:
+        callset = json.loads(genomicsdb.read_entire_file(callset_file))
+        callsets = callset["callsets"]
+        samples = []
+        for callset in callsets:
+            samples.append(callset["sample_name"])
+        print(*samples, sep="\n")
+        sys.exit(0)
+    contigs_map, intervals = parse_vidmap_json(vidmap_file, args.interval)
+    if args.list_contigs:
+        print(*intervals, sep="\n")
+        sys.exit(0)
+    samples = args.sample
     # parse loader.json
     loader = json.loads(genomicsdb.read_entire_file(loader_file))
     partitions = loader["column_partitions"]
+    if not samples and not intervals:
+        raise RuntimeError("Specify at least one of either -i/-interval -s/--sample has to be specified")
 
-    export_config = query_pb.ExportConfiguration()
-    export_config.workspace = workspace
-    export_config.attributes.extend(["REF", "ALT", "GT"])
-    export_config.callset_mapping_file = workspace + "/callset.json"
-    export_config.vid_mapping_file = workspace + "/vidmap.json"
-    export_config.bypass_intersecting_intervals_phase = False
-    export_config.enable_shared_posixfs_optimizations = True
-    if filter:
-        export_config.query_filter = filter
-    gdb = genomicsdb.connect_with_protobuf(export_config)
+    gdb = genomicsdb_connect(workspace, callset_file, vidmap_file, args.filter)
+
+    return gdb, workspace, partitions, contigs_map, intervals, samples, args.output_type, args.output
+
+
+interval_pattern = re.compile(r"(.*):(.*)-(.*)|(.*):(.*)|(.*)")
+
+
+def parse_interval(interval: str):
+    result = re.match(interval_pattern, interval)
+    if result:
+        length = len(result.groups())
+        if length == 6:
+            if result.group(1) and result.group(2) and result.group(3):
+                return result.group(1), int(result.group(2)), int(result.group(3))
+            elif result.group(4) and result.group(5):
+                return result.group(4), int(result.group(5)), None
+            elif result.group(6):
+                return result.group(6), 1, None
+    raise RuntimeError(f"Interval {interval} could not be parsed")
+
+
+def generate_output_filename(output, output_type, interval, idx):
+    output_filename = f"{output}_{interval.replace(':', '-')}"
+    if idx > 0:
+        output_filename = output_filename + f"_{idx}"
+    return output_filename + "." + output_type
+
+
+def main():
+    gdb, workspace, partitions, contigs_map, intervals, samples, output_type, output = setup_gdb()
 
     print(f"Starting genomicsdb_query for workspace({workspace}) and intervals({intervals})")
     for interval in intervals:
@@ -216,16 +261,19 @@ def main():
             contig_interval.contig = contig
             contig_interval.begin = start
             contig_interval.end = end
+            if samples:
+                for sample in samples:
+                    query_config.query_sample_names.append(sample)
             query_config.query_contig_intervals.extend([contig_interval])
             if output_type == "csv":
                 df = gdb.query_variant_calls(query_protobuf=query_config, flatten_intervals=True)
                 df.to_csv(generate_output_filename(output, output_type, interval, idx), index=False)
             elif output_type == "json":
-                json = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.ALL)
+                json_output = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.ALL)
                 with open(generate_output_filename(output, output_type, interval, idx, "wb")) as f:
-                    f.write(json)
+                    f.write(json_output)
 
-    print(f"DONE genomicsdb_query for workspace({workspace}) and intervals({intervals})")
+    print(f"genomicsdb_query for workspace({workspace}) and intervals({intervals}) completed successfully")
 
 
 if __name__ == "__main__":

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -24,14 +24,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-# Description : Python bindings to the native GenomicsDB Library
 #
 
 WORKSPACE=${WORKSPACE:-my_workspace}
 declare -a INTERVALS
 INTERVALS=("1:1-40000000" "2:3000" "3")
 #declare -a SAMPLES
-#SAMPLES={"HG00096", "HG00097", "HG00099"}
+#SAMPLES=("HG00096" "HG00097" "HG00099")
 #VIDMAP_FILE=my_vidmap_file.json
 #LOADER_FILE=my_loader_file.json
 #FILTER='resolve(GT, REF, ALT) &= "T/T"'

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -27,13 +27,15 @@
 # Description : Python bindings to the native GenomicsDB Library
 #
 
-WORKSPACE=my_workspace
+WORKSPACE=${WORKSPACE:-my_workspace}
 declare -a INTERVALS
 INTERVALS=("1:1-40000000" "2:3000" "3")
+#declare -a SAMPLES
+#SAMPLES={"HG00096", "HG00097", "HG00099"}
 #VIDMAP_FILE=my_vidmap_file.json
 #LOADER_FILE=my_loader_file.json
 #FILTER='resolve(GT, REF, ALT) &= "T/T"'
-OUTPUT_FILE=query_output
+OUTPUT_FILE=my_output
 
 
 ###########################################
@@ -50,19 +52,26 @@ fi
 
 for INTERVAL in "${INTERVALS[@]}"
 do
-   INTERVAL_ARGS="$INTERVAL_ARGS -L $INTERVAL"
+   INTERVAL_ARGS="$INTERVAL_ARGS -i $INTERVAL"
 done
+
+if [[ ! -z ${SAMPLES} ]]; then
+  for SAMPLE in "${SAMPLES[@]}"
+  do
+    SAMPLE_ARGS="$SAMPLE_ARGS -s $SAMPLE"
+  done
+fi
 
 if [[ ! -z ${FILTER} ]]; then
   FILTER_EXPR="-f $FILTER"
 fi
 
 if [[ -z ${VIDMAP_FILE} && -z ${LOADER_FILE} ]]; then
-  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS $FILTER_EXPR -o $OUTPUT_FILE
+  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS $SAMPLE_ARGS $FILTER_EXPR -o $OUTPUT_FILE
 elif  [[ -z ${VIDMAP_FILE} ]]; then
-  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -v $VIDMAP_FILE $FILTER_EXPR -o $OUTPUT_FILE
+  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS $SAMPLE_ARGS -v $VIDMAP_FILE $FILTER_EXPR -o $OUTPUT_FILE
 else
-  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -v $VIDMAP_FILE -l $LOADER_FILE $FILTER_EXPR -o $OUTPUT_FILE
+  ./genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS $SAMPLE_ARGS-v $VIDMAP_FILE -l $LOADER_FILE $FILTER_EXPR -o $OUTPUT_FILE
 fi
 
 deactivate

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -34,11 +34,12 @@
 #   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00101.vcf.gz
 # To create a workspace for testing, do the following
 # ~/GenomicsDB/install/bin/vcf2genomicsdb_init -w ws -S ~/vcfs -n 1000
+# ~/GenomicsDB/install/bin/vcf2genomicsdb -r 0 ws/loader.json
 # ~/GenomicsDB/install/bin/vcf2genomicsdb -r 1 ws/loader.json
 # ~/GenomicsDB/install/bin/vcf2genomicsdb -r 2 ws/loader.json
 # ~/GenomicsDB/install/bin/vcf2genomicsdb -r 80 ws/loader.json
 
-WORKSPACE=${WORKSPACE:-my_workspace}
+WORKSPACE=${WORKSPACE:-ws}
 INTERVAL_ARGS="-i 1:1-40000000 -i 2:3000-40000 -i 2:40001 -i 3"
 SAMPLE_ARGS="-s HG00096 -s HG00097 -s HG00099"
 VIDMAP_FILE=vidmap_file.json

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# test query script
+#
+# The MIT License
+#
+# Copyright (c) 2024 dātma, inc™
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#
+
+# Tests run on a workspace importing 5 or more samples from the TCGA 1000G dataset
+#   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00096.vcf.gz
+#   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00097.vcf.gz
+#   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00099.vcf.gz
+#   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00100.vcf.gz
+#   ALL.all_fixed.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.HG00101.vcf.gz
+# To create a workspace for testing, do the following
+# ~/GenomicsDB/install/bin/vcf2genomicsdb_init -w ws -S ~/vcfs -n 1000
+# ~/GenomicsDB/install/bin/vcf2genomicsdb -r 1 ws/loader.json
+# ~/GenomicsDB/install/bin/vcf2genomicsdb -r 2 ws/loader.json
+# ~/GenomicsDB/install/bin/vcf2genomicsdb -r 80 ws/loader.json
+
+WORKSPACE=${WORKSPACE:-my_workspace}
+INTERVAL_ARGS="-i 1:1-40000000 -i 2:3000-40000 -i 2:40001 -i 3"
+SAMPLE_ARGS="-s HG00096 -s HG00097 -s HG00099"
+VIDMAP_FILE=vidmap_file.json
+LOADER_FILE=loader_file.json
+FILTER='ISHOMREF'
+
+
+if [[ $(uname) == "Darwin" ]]; then
+  TEMP_DIR=$(mktemp -d -t test-examples)
+else
+  TEMP_DIR=$(mktemp -d -t test-examples-XXXXXXXXXX)
+fi
+
+OUTPUT="$TEMP_DIR/out"
+
+cleanup() {
+  rm -fr $TEMP_DIR
+}
+
+die() {
+  cleanup
+  if [[ $# -eq 1 ]]; then
+    echo $1
+  fi
+  exit 1
+}
+
+# run_command
+#    $1 : command to be executed
+#    $2 : optional - 0(default) if command should return successfully
+#                    any other value if the command should return a failure
+run_command() {
+  echo $EMPTY > $TEMP_DIR/output
+  declare -i EXPECT_NZ
+  declare -i GOT_NZ
+  EXPECT_NZ=0
+  GOT_NZ=0
+  if [[ $# -eq 2 && $2 -ne 0 ]]; then
+    EXPECT_NZ=1
+  fi
+  # Execute the command redirecting all output to $TEMP_DIR/output
+  $($1 &> $TEMP_DIR/output)
+  retval=$?
+
+  if [[ $retval -ne 0 ]]; then
+    GOT_NZ=1
+  fi
+
+  if [[ $(($GOT_NZ ^ $EXPECT_NZ)) -ne 0 ]]; then
+    cat $TEMP_DIR/output
+    die "command '`echo $1`' returned $retval unexpectedly"
+  fi
+}
+
+PATH=.:$PATH
+run_command "genomicsdb_query" 2
+run_command "genomicsdb_query -h"
+run_command "genomicsdb_query --version"
+run_command "genomicsdb_query --list-samples" 2
+run_command "genomicsdb_query --list-contigs" 2
+run_command "genomicsdb_query -w $WORKSPACE" 1
+run_command "genomicsdb_query -w $WORKSPACE -i xx -S XX" 1
+
+if [[ ! -d $WORKSPACE ]]; then
+  echo "Specify an existing workspace in env WORKSPACE"
+  exit 1
+fi
+
+genomicsdb_query -w $WORKSPACE --list-contigs > $TEMP_DIR/contigs.list
+genomicsdb_query -w $WORKSPACE --list-samples > $TEMP_DIR/samples.list
+
+declare -a FILES
+FILES=("1-1-40000000", "1-1-40000000_1", "2-3000-40000", "2-40001")
+run_command "genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -o $OUTPUT"
+for FILE in "${INTERVALS[@]}"
+do
+  if [[ ! -f $OUTPUT_$FILE.csv ]]; then
+    echo "Could not find file=$OUTPUT_$FILE.csv"
+    exit 1
+  fi
+done
+run_command "genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -o $OUTPUT --output-type json" 
+for FILE in "${INTERVALS[@]}"
+do
+  if [[ ! -f $OUTPUT_$FILE.json ]]; then
+    echo "Could not find file=$OUTPUT_$FILE.json"
+    exit 1
+  fi
+done
+
+run_command "genomicsdb_query -w $WORKSPACE -I $TEMP_DIR/contigs.list -s HG00096"
+run_command "genomicsdb_query -w $WORKSPACE -I $TEMP_DIR/contigs.list -S $TEMP_DIR/samples.list"
+run_command "genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -S $TEMP_DIR/samples.list"
+run_command "genomicsdb_query -w $WORKSPACE $INTERVAL_ARGS -S $TEMP_DIR/samples.list -f $FILTER"
+
+cleanup


### PR DESCRIPTION
Support sample specification instead or in addition to intervals to the tool. See https://github.com/GenomicsDB/GenomicsDB-Python/pull/57#issuecomment-2436590469

We should now be able to 
1. query genomic regions, optionally subsetted by samples(specified with `--interval` or `--interval/--sample` together)
2. query all genomic regions from some subset of samples(specified with only the `--sample` option)

`--list-samples` and  `--list-contigs` are helper options, where we just list the samples/contigs in the workspace and quit processing. For ease, use `--interval-list` and `--sample-list` options to specify interval/sample list files instead of specifying `--interval/--sample` arguments repeatedly.

We now allow either csv or json output, through the `--output-type` option.

The current implementation just passes the list of sample names via QueryConfiguration protobuf and relies on the native library to do the mapping of the samples to the rows. We could do that from python directly and merge the resulting contiguous row numbers into a tuple to pass instead of sample names via protobuf. Any thoughts on this?