### PR TITLE
Changes to cache json files and use gnu parallel to run multiple instances of genomicsdb_query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,14 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 format: ## format files with black and isort
-	black --line-length 120 setup.py src test examples/genomicsdb_query
-	isort --profile black --line-length 120 setup.py src test examples/genomicsdb_query
+	black --line-length 120 setup.py src test examples/genomicsdb_*
+	isort --profile black --line-length 120 setup.py src test examples/genomicsdb_*
 
 lint: ## check style with flake8 and vulnerabilities with bandit
 	bandit -r setup.py src
-	flake8 --extend-ignore='E203, N803, N806, E402' --max-line-length=120 setup.py src test examples/genomicsdb_query
-	black --check --line-length 120 setup.py src test examples/genomicsdb_query
-	isort --profile black --line-length 120 -c setup.py src test examples/genomicsdb_query
+	flake8 --extend-ignore='E203, N803, N806, E402' --max-line-length=120 setup.py src test examples/genomicsdb_*
+	black --check --line-length 120 setup.py src test examples/genomicsdb_*
+	isort --profile black --line-length 120 -c setup.py src test examples/genomicsdb_*
 	cython-lint --max-line-length 120 src/*.pyx
 
 test: FORCE ## run tests quickly with the default Python

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 ## GenomicsDB simple query tool
 
+Note that there is `run.sh` bash script for ease of use and if you do not want to invoke the genomicsdb_query CLI directly.
+
 Simple GenomicsDB query tool `genomicsdb_query`, given a workspace and genomic intervals of the form `<CONTIG>:<START>-<END>`.  The intervals at a minimum need to have the contig specified, start and end are optional. e.g chr1:100-1000, chr1:100 and chr1 are all valid. Start defaults to 1 if not specified and end defaults to the length of the contig if not specified.
 
 Assumption : The workspace should have been created with the `vcf2genomicsdb` tool or with `gatk GenomicsDBImport` and should exist.
@@ -23,6 +25,7 @@ options:
                         Optional - URL to loader file. Defaults to loader.json in workspace
   --list-samples        List samples ingested into the workspace and exit
   --list-contigs        List contigs for the ingested samples in the workspace and exit
+  --list-partitions     List interval partitions for the ingested samples in the workspace and exit
   -i INTERVAL, --interval INTERVAL
                         genomic intervals over which to operate. The intervals should be specified in the <CONTIG>:<START>-<END> format with START and END optional.
                         This argument may be specified 0 or more times e.g -i chr1:1-10000 -i chr2 -i chr3:1000. 

--- a/examples/genomicsdb_cache
+++ b/examples/genomicsdb_cache
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+#
+# genomicsdb_cache python script
+#
+# The MIT License
+#
+# Copyright (c) 2024 dātma, inc™
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import genomicsdb
+import argparse
+import os
+
+def normalize_path(path):
+    if "://" in path:
+        return path
+    else:
+        return os.path.abspath(path)
+
+def is_cloud_path(path):
+    if "://" in path:
+      return True
+    else:
+        return False
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cache",
+        description="Cache GenomicsDB generated json artifacts for workspace cloud URLs",
+        formatter_class=argparse.RawTextHelpFormatter,
+        usage="%(prog)s [options]",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=genomicsdb.version(),
+        help="print GenomicsDB native library version and exit",
+    )
+    parser.add_argument(
+        "-w",
+        "--workspace",
+        required=True,
+        help="URL to GenomicsDB workspace \ne.g. -w my_workspace or -w az://my_container/my_workspace"
+        + " or -w s3://my_bucket/my_workspace or -w gs://my_bucket/my_workspace",
+    )
+    parser.add_argument(
+        "-v",
+        "--vidmap",
+        required=False,
+        help="Optional - URL to vid mapping file. Defaults to vidmap.json in workspace",
+    )
+    parser.add_argument(
+        "-c",
+        "--callset",
+        required=False,
+        help="Optional - URL to callset mapping file. Defaults to callset.json in workspace",
+    )
+    parser.add_argument(
+        "-l", "--loader", required=False, help="Optional - URL to loader file. Defaults to loader.json in workspace"
+    )
+
+    args = parser.parse_args()
+
+    workspace = normalize_path(args.workspace)
+    if not genomicsdb.is_file(workspace + "/__tiledb_workspace.tdb"):
+       raise RuntimeError(f"workspace({workspace}) not found")
+
+    callset_file = args.callset
+    if not callset_file:
+        callset_file = workspace + "/callset.json"
+    vidmap_file = args.vidmap
+    if not vidmap_file:
+        vidmap_file = workspace + "/vidmap.json"
+    loader_file = args.loader
+    if not loader_file:
+        loader_file = workspace + "/loader.json"
+    if (not genomicsdb.is_file(callset_file)
+        or not genomicsdb.is_file(vidmap_file)
+        or not genomicsdb.is_file(loader_file)
+        ):
+        raise RuntimeError(f"callset({callset_file}) vidmap({vidmap_file}) or loader({loader_file}) not found")
+
+    if is_cloud_path(callset_file):
+        with open("callset.json", "wb") as f:
+            f.write(genomicsdb.read_entire_file(callset_file).encode())
+    if is_cloud_path(vidmap_file):
+        with open("vidmap.json", "wb") as f:
+            f.write(genomicsdb.read_entire_file(vidmap_file).encode())
+    if is_cloud_path(loader_file):
+        with open("loader.json", "wb") as f:
+            f.write(genomicsdb.read_entire_file(loader_file).encode())
+
+if __name__ == "__main__":
+    main()

--- a/examples/genomicsdb_cache
+++ b/examples/genomicsdb_cache
@@ -26,9 +26,11 @@
 # THE SOFTWARE.
 #
 
-import genomicsdb
 import argparse
 import os
+
+import genomicsdb
+
 
 def normalize_path(path):
     if "://" in path:
@@ -36,11 +38,13 @@ def normalize_path(path):
     else:
         return os.path.abspath(path)
 
+
 def is_cloud_path(path):
     if "://" in path:
-      return True
+        return True
     else:
         return False
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -82,7 +86,7 @@ def main():
 
     workspace = normalize_path(args.workspace)
     if not genomicsdb.is_file(workspace + "/__tiledb_workspace.tdb"):
-       raise RuntimeError(f"workspace({workspace}) not found")
+        raise RuntimeError(f"workspace({workspace}) not found")
 
     callset_file = args.callset
     if not callset_file:
@@ -93,10 +97,11 @@ def main():
     loader_file = args.loader
     if not loader_file:
         loader_file = workspace + "/loader.json"
-    if (not genomicsdb.is_file(callset_file)
+    if (
+        not genomicsdb.is_file(callset_file)
         or not genomicsdb.is_file(vidmap_file)
         or not genomicsdb.is_file(loader_file)
-        ):
+    ):
         raise RuntimeError(f"callset({callset_file}) vidmap({vidmap_file}) or loader({loader_file}) not found")
 
     if is_cloud_path(callset_file):
@@ -108,6 +113,7 @@ def main():
     if is_cloud_path(loader_file):
         with open("loader.json", "wb") as f:
             f.write(genomicsdb.read_entire_file(loader_file).encode())
+
 
 if __name__ == "__main__":
     main()

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -39,7 +39,7 @@ from genomicsdb.protobuf import genomicsdb_export_config_pb2 as query_pb
 
 
 def parse_vidmap_json(vidmap_file, intervals=None):
-    if isinstance(intervals) == str:
+    if isinstance(intervals, str):
         is_file = True
     else:
         is_file = False
@@ -71,7 +71,7 @@ def parse_callset_json_for_row_ranges(callset_file, samples=None):
         return None
     callset = json.loads(genomicsdb.read_entire_file(callset_file))
     callsets = callset["callsets"]
-    if isinstance(samples) == str:
+    if isinstance(samples, str):
         with open(samples) as file:
             samples = [line.rstrip() for line in file]
     rows = [callset["row_idx"] for sample in samples for callset in callsets if sample == callset["sample_name"]]
@@ -95,6 +95,13 @@ def parse_callset_json_for_row_ranges(callset_file, samples=None):
     return row_tuples
 
 
+def parse_loader_json(loader_file):
+    loader = json.loads(genomicsdb.read_entire_file(loader_file))
+    partitions = loader["column_partitions"]
+    array_names = [partition["array_name"] for partition in partitions]
+    return [name.replace("$", ":", 1).replace("$", "-", 1) for name in array_names]
+
+
 def genomicsdb_connect(workspace, callset_file, vidmap_file, filter):
     export_config = query_pb.ExportConfiguration()
     export_config.workspace = workspace
@@ -106,6 +113,12 @@ def genomicsdb_connect(workspace, callset_file, vidmap_file, filter):
     if filter:
         export_config.query_filter = filter
     return genomicsdb.connect_with_protobuf(export_config)
+
+def normalize_path(path):
+    if "://" in path:
+        return path
+    else:
+        return os.path.abspath(path)
 
 
 def setup_gdb():
@@ -147,6 +160,8 @@ def setup_gdb():
     parser.add_argument(
         "--list-contigs", action="store_true", help="List contigs for the ingested samples in the workspace and exit"
     )
+    parser.add_argument(
+        "--list-partitions", action="store_true", help="List interval partitions for the ingested samples in the workspace and exit")
     parser.add_argument(
         "-i",
         "--interval",
@@ -195,7 +210,7 @@ def setup_gdb():
 
     args = parser.parse_args()
 
-    workspace = os.path.abspath(args.workspace)
+    workspace = normalize_path(args.workspace)
     if not genomicsdb.is_file(workspace + "/__tiledb_workspace.tdb"):
         raise RuntimeError(f"workspace({workspace}) not found")
     callset_file = args.callset
@@ -222,6 +237,12 @@ def setup_gdb():
     if args.list_samples:
         samples = parse_callset_json(callset_file)
         print(*samples, sep="\n")
+        sys.exit(0)
+
+    if args.list_partitions:
+        # parse loader.json for partitions
+        partitions = parse_loader_json(loader_file)
+        print(*partitions, sep="\n")
         sys.exit(0)
 
     intervals = args.interval
@@ -306,10 +327,6 @@ def main():
         for partition in partitions:
             if contig_end < partition["begin"]["tiledb_column"] or contig_offset > partition["end"]["tiledb_column"]:
                 continue
-            if partition["workspace"] != workspace:
-                raise RuntimeError(
-                    f"Partiton workspaces({partition['workspace']} different from input workspace({workspace}) not supported"  # noqa
-                )
             arrays.append(partition["array_name"])
 
         arrays_length = len(arrays)
@@ -335,7 +352,7 @@ def main():
                 df = gdb.query_variant_calls(query_protobuf=query_config, flatten_intervals=True)
                 df.to_csv(generate_output_filename(output, output_type, interval, idx), index=False)
             elif output_type == "json":
-                json_output = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.ALL)
+                json_output = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.SAMPLES_WITH_NUM_CALLS)
                 with open(generate_output_filename(output, output_type, interval, idx), "wb") as f:
                     f.write(json_output)
 

--- a/examples/genomicsdb_query
+++ b/examples/genomicsdb_query
@@ -114,6 +114,7 @@ def genomicsdb_connect(workspace, callset_file, vidmap_file, filter):
         export_config.query_filter = filter
     return genomicsdb.connect_with_protobuf(export_config)
 
+
 def normalize_path(path):
     if "://" in path:
         return path
@@ -161,7 +162,10 @@ def setup_gdb():
         "--list-contigs", action="store_true", help="List contigs for the ingested samples in the workspace and exit"
     )
     parser.add_argument(
-        "--list-partitions", action="store_true", help="List interval partitions for the ingested samples in the workspace and exit")
+        "--list-partitions",
+        action="store_true",
+        help="List interval partitions for the ingested samples in the workspace and exit",
+    )
     parser.add_argument(
         "-i",
         "--interval",
@@ -352,7 +356,9 @@ def main():
                 df = gdb.query_variant_calls(query_protobuf=query_config, flatten_intervals=True)
                 df.to_csv(generate_output_filename(output, output_type, interval, idx), index=False)
             elif output_type == "json":
-                json_output = gdb.query_variant_calls(query_protobuf=query_config, json_output=json_output_mode.SAMPLES_WITH_NUM_CALLS)
+                json_output = gdb.query_variant_calls(
+                    query_protobuf=query_config, json_output=json_output_mode.SAMPLES_WITH_NUM_CALLS
+                )
                 with open(generate_output_filename(output, output_type, interval, idx), "wb") as f:
                     f.write(json_output)
 


### PR DESCRIPTION
Note that TILEDB_CACHE support for bookkeeping files needs this PR - https://github.com/datma-health/TileDB/pull/177 to be merged.

Introduced a new tool `genomicsdb_cache` to cache the json files locally before invoking `genomicsdb_query`. Also added option to genomicsdb_query - `--list-partitions` to list the available partitions(with associated GenomicsDB arrays) to help the user figure out suitable intervals for query.