### PR TITLE
Move GitHub action builds to macOS-13 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           CIBW_BEFORE_ALL: "OSX_ARCH='arm64' INSTALL_PREFIX=${{ env.INSTALL_PREFIX }} .github/scripts/install_prereqs.sh release"
           CIBW_BEFORE_BUILD: "pip install -r {package}/requirements_dev.txt && cd {package}"
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
-          CIBW_CONFIG_SETTINGS: "--build-option=--with-version=${{ needs.version_number.outputs.version }} --build-option=--with-genomicsdb=${{ env.INSTALL_PREFIX }}"
+          CIBW_CONFIG_SETTINGS: "--global-option=--with-version=${{ needs.version_number.outputs.version }} --build-option=--with-genomicsdb=${{ env.INSTALL_PREFIX }}"
           CIBW_ENVIRONMENT: DYLD_LIBRARY_PATH=${{ env.INSTALL_PREFIX }}/lib
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install -r {package}/requirements_dev.txt && cd {package}"
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*musllinux*"
-          CIBW_CONFIG_SETTINGS: "--build-option=--with-version=${{ needs.version_number.outputs.version }} --build-option=--with-genomicsdb=${{ env.INSTALL_PREFIX }}"
+          CIBW_CONFIG_SETTINGS: "--global-option=--with-version=${{ needs.version_number.outputs.version }} --build-option=--with-genomicsdb=${{ env.INSTALL_PREFIX }}"
           CIBW_ENVIRONMENT: CMAKE_PREFIX_PATH=${{ env.INSTALL_PREFIX }}
           CIBW_ENVIRONMENT_MACOS: DYLD_LIBRARY_PATH=${{ env.INSTALL_PREFIX }}/lib
           CIBW_ENVIRONMENT_LINUX: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-22.04]
+        os: [macos-13, ubuntu-22.04]
     env:
        INSTALL_PREFIX: ${{ github.workspace }}/prereqs
        MACOSX_DEPLOYMENT_TARGET: 12.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   build_macos_arm64_wheels:
     name: Build wheels for macOS arm64
     needs: version_number
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       INSTALL_PREFIX: ${{ github.workspace }}/prereqs_arm64
       MACOSX_DEPLOYMENT_TARGET: 12.1

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ for arg in args:
         with_version = arg.split("=")[1]
         sys.argv.remove(arg)
 
+print("GenomicsDB-Python Version={}".format(with_version))
 print("Compiled GenomicsDB Install Path: {}".format(GENOMICSDB_INSTALL_PATH))
 
 GENOMICSDB_INCLUDE_DIR = os.path.join(GENOMICSDB_INSTALL_PATH, "include")

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ GENOMICSDB_LOCAL_DATA_DIR = "genomicsdb"
 GENOMICSDB_INSTALL_PATH = os.getenv("GENOMICSDB_HOME", default="genomicsdb")
 copy_genomicsdb_libs = False
 copy_protobuf_definitions = False
-with_version = "0.0.9.17"
+with_version = "0.0.9.14"
 
 args = sys.argv[:]
 for arg in args:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ GENOMICSDB_LOCAL_DATA_DIR = "genomicsdb"
 GENOMICSDB_INSTALL_PATH = os.getenv("GENOMICSDB_HOME", default="genomicsdb")
 copy_genomicsdb_libs = False
 copy_protobuf_definitions = False
-with_version = "0.0.9.14"
+with_version = "0.0.9.17"
 
 args = sys.argv[:]
 for arg in args:
@@ -58,7 +58,6 @@ for arg in args:
         with_version = arg.split("=")[1]
         sys.argv.remove(arg)
 
-print("GenomicsDB-Python Version={}".format(with_version))
 print("Compiled GenomicsDB Install Path: {}".format(GENOMICSDB_INSTALL_PATH))
 
 GENOMICSDB_INCLUDE_DIR = os.path.join(GENOMICSDB_INSTALL_PATH, "include")


### PR DESCRIPTION
- Move GitHub action builds to macOS-13 runners.
- Also use `global-option` instead of `build-option` as arguments to the `wheel` package as it does not seem to be passing `--with-version` option to setup.py. At some point we should move to a more modern system of building, but this workaround seems to be functional for now.