### PR TITLE
 Filter out duplicate intervals specified in the examples/genomicsdb_query command line

### DIFF
--- a/examples/genomicsdb_common.py
+++ b/examples/genomicsdb_common.py
@@ -74,7 +74,7 @@ def parse_vidmap_json(vidmap_file, intervals=None):
         column_offset += contig_elem["length"]
         if all_intervals:
             intervals.append(contig_name)
-    return contigs_map, intervals
+    return contigs_map, set(intervals)
 
 
 def parse_interval(interval: str):


### PR DESCRIPTION
Duplicate samples are already filtered out, duplicate intervals are now filtered as well and we now have tests for both duplicate samples as well as intervals.